### PR TITLE
Object Rewind

### DIFF
--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed6ed6f32c99c094589658bd02ebf533
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/TestCube.prefab
+++ b/Assets/Prefabs/TestCube.prefab
@@ -125,5 +125,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e402f182bfe19004588e0e21fb2edf97, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  rewindTime: 2
+  maxRewindTime: 5
   timeBetweenSaves: 0.2

--- a/Assets/Prefabs/TestCube.prefab
+++ b/Assets/Prefabs/TestCube.prefab
@@ -1,0 +1,129 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &664090465299294142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 664090465299294143}
+  - component: {fileID: 664090465299294131}
+  - component: {fileID: 664090465299294130}
+  - component: {fileID: 664090465299294141}
+  - component: {fileID: 664090465299294140}
+  - component: {fileID: 664090465299294128}
+  m_Layer: 0
+  m_Name: TestCube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &664090465299294143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664090465299294142}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &664090465299294131
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664090465299294142}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &664090465299294130
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664090465299294142}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &664090465299294141
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664090465299294142}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &664090465299294140
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664090465299294142}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &664090465299294128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 664090465299294142}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e402f182bfe19004588e0e21fb2edf97, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rewindTime: 2
+  timeBetweenSaves: 0.2

--- a/Assets/Prefabs/TestCube.prefab
+++ b/Assets/Prefabs/TestCube.prefab
@@ -125,5 +125,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e402f182bfe19004588e0e21fb2edf97, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxRewindTime: 5
+  rewindTime: 2
+  rewindCooldown: 2
   timeBetweenSaves: 0.2

--- a/Assets/Prefabs/TestCube.prefab.meta
+++ b/Assets/Prefabs/TestCube.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 699724161ac170f4b95476ce9ca1f8b7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/ObjectRewind_CDoming.unity
+++ b/Assets/Scenes/ObjectRewind_CDoming.unity
@@ -1,0 +1,926 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 705507994}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 1990944023}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &205794855
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 296497971}
+    m_Modifications:
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_Name
+      value: Cube (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+--- !u!4 &205794856 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+  m_PrefabInstance: {fileID: 205794855}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &296497970
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 296497971}
+  m_Layer: 0
+  m_Name: CubePile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &296497971
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 296497970}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1347673717}
+  - {fileID: 205794856}
+  - {fileID: 919101024}
+  - {fileID: 1646597774}
+  - {fileID: 308218122}
+  - {fileID: 2109733202}
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &308218121
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 296497971}
+    m_Modifications:
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_Name
+      value: Cube (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+--- !u!4 &308218122 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+  m_PrefabInstance: {fileID: 308218121}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &705507993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 705507995}
+  - component: {fileID: 705507994}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &705507994
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &705507995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: -1.65, y: 7.96, z: 2.86}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &769597141
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 769597143}
+  - component: {fileID: 769597142}
+  m_Layer: 0
+  m_Name: ExplosionSource
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &769597142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769597141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f9027736422e8d44b682951c08234c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  radius: 5
+  power: 600
+--- !u!4 &769597143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769597141}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &919101023
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 296497971}
+    m_Modifications:
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_Name
+      value: Cube (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+--- !u!4 &919101024 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+  m_PrefabInstance: {fileID: 919101023}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &963194225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 963194228}
+  - component: {fileID: 963194227}
+  - component: {fileID: 963194226}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &963194226
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+--- !u!20 &963194227
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &963194228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1347673717 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+  m_PrefabInstance: {fileID: 664090463953795530}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1646597773
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 296497971}
+    m_Modifications:
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_Name
+      value: Cube (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+--- !u!4 &1646597774 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+  m_PrefabInstance: {fileID: 1646597773}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1819075863
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1819075867}
+  - component: {fileID: 1819075866}
+  - component: {fileID: 1819075865}
+  - component: {fileID: 1819075864}
+  m_Layer: 0
+  m_Name: Platform
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1819075864
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819075863}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1819075865
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819075863}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1819075866
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819075863}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1819075867
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819075863}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 100, y: 1, z: 100}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!850595691 &1990944023
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Settings.lighting
+  serializedVersion: 3
+  m_GIWorkflowMode: 1
+  m_EnableBakedLightmaps: 1
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 1
+  m_BakeBackend: 1
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_TextureCompression: 1
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 2
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 500
+  m_PVREnvironmentSampleCount: 500
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 1
+  m_PVREnvironmentMIS: 0
+  m_PVRFilteringMode: 2
+  m_PVRDenoiserTypeDirect: 0
+  m_PVRDenoiserTypeIndirect: 0
+  m_PVRDenoiserTypeAO: 0
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
+--- !u!1001 &2109733201
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 296497971}
+    m_Modifications:
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_Name
+      value: Cube (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+--- !u!4 &2109733202 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+  m_PrefabInstance: {fileID: 2109733201}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &664090463953795530
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 296497971}
+    m_Modifications:
+    - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_Name
+      value: Cube
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294143, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}

--- a/Assets/Scenes/ObjectRewind_CDoming.unity
+++ b/Assets/Scenes/ObjectRewind_CDoming.unity
@@ -874,6 +874,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 296497971}
     m_Modifications:
+    - target: {fileID: 664090465299294128, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: rewindTime
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664090465299294128, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
+      propertyPath: rewindCooldown
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 664090465299294142, guid: 699724161ac170f4b95476ce9ca1f8b7, type: 3}
       propertyPath: m_Name
       value: Cube

--- a/Assets/Scenes/ObjectRewind_CDoming.unity.meta
+++ b/Assets/Scenes/ObjectRewind_CDoming.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a50997271dc7fba4f8d7ac0682da99a9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Explosion.cs
+++ b/Assets/Scripts/Explosion.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Simulates an explosion from an attached object.
+ * Press 'Space' to initiate the explosion.
+ * 
+ * Author: Cristion Dominguez
+ * Date: 22 July 2021
+ */
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Explosion : MonoBehaviour
+{
+    [SerializeField]
+    [Tooltip("Radius objects shall be affected in.")]
+    private float radius = 5f;
+
+    [SerializeField]
+    [Tooltip("Force applied to affected objects.")]
+    private float power = 600f;
+
+    private Vector3 position;
+    private Collider[] colliders;
+
+    public void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            Explode();
+        }
+    }
+
+    public void Explode()
+    {
+        position = transform.position;
+        colliders = Physics.OverlapSphere(position, radius);
+
+        foreach(Collider hit in colliders)
+        {
+            Rigidbody rb = hit.GetComponent<Rigidbody>();
+
+            if (rb != null)
+            {
+                rb.AddExplosionForce(power, position, radius, 3.0f);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Explosion.cs.meta
+++ b/Assets/Scripts/Explosion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f9027736422e8d44b682951c08234c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ObjectRewind.cs
+++ b/Assets/Scripts/ObjectRewind.cs
@@ -1,7 +1,8 @@
 ﻿/*
  * Records past references of an object at defined intervals after the object moves for the 1st time.
- * Pressing 'W' rewinds the object to its previous location.
- * Releasing 'W' allows the object to continue normal movement, inheriting velocity and angular velocity from the most recent reference.
+ * Holding [R] rewinds the object to its previous location.
+ * Releasing [R] allows the object to move with forward time, inheriting velocity and angular velocity from the most recent reference.
+ * A cooldown is then imposed on the rewinding mechanic for the object, which is determined by how long the Player rewound the object for.
  * 
  * Possible Improvements:
     * Method or script to calculate the proper velocity and angular velocity of the object when time is moved forward.
@@ -15,6 +16,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// Information about an object at a certain time.
+/// </summary>
 public struct PastReference
 {
     public Vector3 position;
@@ -34,42 +38,59 @@ public struct PastReference
 public class ObjectRewind : MonoBehaviour
 {
     [SerializeField]
-    [Tooltip("Total time for rewind.")]
-    private float rewindTime = 2f;
+    [Tooltip("Total time the object can be rewound.")]
+    private float maxRewindTime = 2f;
 
     [SerializeField]
-    [Tooltip("Time between saving object information for rewind.")]
+    [Tooltip("Time between saving object information for rewinding.")]
     private float timeBetweenSaves = 0.2f;
 
-    private List<PastReference> references;
-    private Rigidbody objectPhysics;
+    private List<PastReference> references;  // saved references of the object
+    private Rigidbody objectPhysics;  // for gathering object velocity and angular velocity
 
-    private float maxPoints;
-    private float timeSinceLastSave = 0f;
+    private float maxReferences;  // max amount of references that can be saved
+    private float timeSinceLastSave = 0f;  // time since the latest reference was saved
+    private float rewindCooldown = 0f;  //  cooldown after the rewind finishes
 
-    private bool isRewinding = false;
-    private bool isMoving = false;
+    private bool canInitiateRewind = true;  // Is the object moving with forward time and is the cooldown inactive?
+    private bool isRewinding = false;  // Is the object rewinding?
+    private bool hasMoved = false;  // Has the object moved?    
 
+    /// <summary>
+    /// Initializes reference list and object physics, calculates the max amount of references to be saved, and records the first reference.
+    /// </summary>
     private void Start()
     {
         references = new List<PastReference>();
         objectPhysics = transform.GetComponent<Rigidbody>();
 
-        maxPoints =  Mathf.Round(rewindTime / timeBetweenSaves);
+        maxReferences =  Mathf.Round(maxRewindTime / timeBetweenSaves);
         Record();
     }
 
+    /// <summary>
+    /// Rewinds the object if the Player hold down the rewind button and the object can start rewinding. Otherwise, ceases the object from rewinding.
+    /// </summary>
     private void Update()
     {
-        if(Input.GetKeyDown(KeyCode.W))
+        if(Input.GetKey(KeyCode.R) && canInitiateRewind)
         {
+            isRewinding = true;
             StartCoroutine(Rewind());
+        }
+        else if(Input.GetKeyUp(KeyCode.R))
+        {
+            isRewinding = false;
         }
     }
 
+    /// <summary>
+    /// Records references for the object after it has moved and is not rewinding.
+    /// </summary>
     public void FixedUpdate()
     {
-        if (isMoving && !isRewinding)
+        // If the object has moved and is not rewinding, then update the time since the last reference save and once it surpasses the time between saves, record a reference and reset the time since last reference.
+        if (hasMoved && !isRewinding)
         {
             if(timeSinceLastSave < timeBetweenSaves)
             {
@@ -81,61 +102,74 @@ public class ObjectRewind : MonoBehaviour
                 timeSinceLastSave = 0f;
             }
         }
+        // Commence recording references when the object's velocity and angular velocity reach a certain magnitude.
         else if (objectPhysics.velocity.magnitude >= 0.01 || objectPhysics.angularVelocity.magnitude >= 0.01)
         {
-            isMoving = true;
+            hasMoved = true;
         }
     }
 
+    /// <summary>
+    /// Rewinds the object to previous references.
+    /// </summary>
     private IEnumerator Rewind()
     {
-        isRewinding = true;
-        objectPhysics.isKinematic = true;
+        // Do not allow another Rewind coroutine to run and reset the rewind cooldown.
+        canInitiateRewind = false;
+        rewindCooldown = 0f;
 
-        PastReference pointInTime;
+        // Declare variables.
+        PastReference referenceToReach;
         Vector3 initialPosition, finalPosition;
         Quaternion initialRotation, finalRotation;
         float elapsedTime = 0f;
         float timeToPreviousReference;
-
-        Vector3 velocity = objectPhysics.velocity;
-        Vector3 angularVelocity = objectPhysics.angularVelocity;
-
         bool isFromAReference = false;
 
+        // Save the object velocity and angular velocity before freezing the object.
+        Vector3 velocity = objectPhysics.velocity;
+        Vector3 angularVelocity = objectPhysics.angularVelocity;
+        objectPhysics.isKinematic = true;
+
+        // Whilst [R] is being held down and there are saved references, lerp the object's position and rotation to its past references.
         while(isRewinding && references.Count > 0)
         {
-            pointInTime = references[references.Count - 1];
-            velocity = pointInTime.velocity;
-            angularVelocity = pointInTime.angularVelocity;
+            // Assign the closest past reference as the reference for the object to reach, and save the reference's velocity and angular velocity.
+            referenceToReach = references[references.Count - 1];
+            velocity = referenceToReach.velocity;
+            angularVelocity = referenceToReach.angularVelocity;
 
+            // Assign positions and rotations for lerping.
             initialPosition = transform.position;
-            finalPosition = pointInTime.position;
-
+            finalPosition = referenceToReach.position;
             initialRotation = transform.rotation;
-            finalRotation = pointInTime.rotation;
+            finalRotation = referenceToReach.rotation;
 
-            if (!isFromAReference)
+            // If the object is rewinding from a reference it met, then the total time for lerping is the time between reference saves.
+            // Otherwise, the total time for lerping is the time after the last reference was saved.
+            if (isFromAReference)
+            {
+                timeToPreviousReference = timeBetweenSaves;
+            }
+            else
             {
                 timeToPreviousReference = timeSinceLastSave;
                 isFromAReference = true;
             }
-            else
-            {
-                timeToPreviousReference = timeBetweenSaves;
-            }
             
+            // Lerp the object to the reference to reach whilst the Player is holding the rewind button, updating the rewind cooldown.
             elapsedTime = 0f;
-
             while(isRewinding && elapsedTime < timeToPreviousReference)
             {
                 transform.position = Vector3.Lerp(initialPosition, finalPosition, elapsedTime / timeToPreviousReference);
                 transform.rotation = Quaternion.Lerp(initialRotation, finalRotation, elapsedTime / timeToPreviousReference);
 
                 elapsedTime += Time.deltaTime;
+                rewindCooldown += Time.deltaTime;
                 yield return null;
             }
 
+            // If the time lerping surpasses the time to the previous reference, then snap the object to the reference's position and rotation as well as removing the reference from the save list.
             if(elapsedTime >= timeToPreviousReference)
             {
                 transform.position = finalPosition;
@@ -146,17 +180,33 @@ public class ObjectRewind : MonoBehaviour
         }
 
         isRewinding = false;
-        objectPhysics.isKinematic = false;
-
+        
+        // Grant the object the velocity and angular velocity of the closest reference, and allow it to move with forward time.
         objectPhysics.velocity = velocity;
         objectPhysics.angularVelocity = angularVelocity;
+        objectPhysics.isKinematic = false;
 
+        // Update the time since last reference save and activate the cooldown.
         timeSinceLastSave = timeBetweenSaves - elapsedTime;
+        StartCoroutine(RunCooldown());
     }
 
+    /// <summary>
+    /// Denies the object from being rewound for the time it has been rewinding after the object has regained forward movement.
+    /// </summary>
+    private IEnumerator RunCooldown()
+    {
+        yield return new WaitForSeconds(rewindCooldown);
+        canInitiateRewind = true;
+
+    }
+
+    /// <summary>
+    /// Saves a new reference of the object. If the reference limit has been met, the oldest reference is removed to allow the newest reference in the list.
+    /// </summary>
     private void Record()
     {
-        if(references.Count > maxPoints)
+        if(references.Count > maxReferences)
         {
             references.RemoveAt(0);
         }

--- a/Assets/Scripts/ObjectRewind.cs
+++ b/Assets/Scripts/ObjectRewind.cs
@@ -1,0 +1,166 @@
+﻿/*
+ * Records past references of an object at defined intervals after the object moves for the 1st time.
+ * Pressing 'W' rewinds the object to its previous location.
+ * Releasing 'W' allows the object to continue normal movement, inheriting velocity and angular velocity from the most recent reference.
+ * 
+ * Possible Improvements:
+    * Method or script to calculate the proper velocity and angular velocity of the object when time is moved forward.
+    * Record a reference of the object after cancelling rewind.
+ * 
+ * Author: Cristion Dominguez
+ * Date: 22 July 2021
+ */
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public struct PastReference
+{
+    public Vector3 position;
+    public Quaternion rotation;
+    public Vector3 velocity;
+    public Vector3 angularVelocity;
+
+    public PastReference(Vector3 position, Quaternion rotation, Vector3 velocity, Vector3 angularVelocity)
+    {
+        this.position = position;
+        this.rotation = rotation;
+        this.velocity = velocity;
+        this.angularVelocity = angularVelocity;
+    }
+}
+
+public class ObjectRewind : MonoBehaviour
+{
+    [SerializeField]
+    [Tooltip("Total time for rewind.")]
+    private float rewindTime = 2f;
+
+    [SerializeField]
+    [Tooltip("Time between saving object information for rewind.")]
+    private float timeBetweenSaves = 0.2f;
+
+    private List<PastReference> references;
+    private Rigidbody objectPhysics;
+
+    private float maxPoints;
+    private float timeSinceLastSave = 0f;
+
+    private bool isRewinding = false;
+    private bool isMoving = false;
+
+    private void Start()
+    {
+        references = new List<PastReference>();
+        objectPhysics = transform.GetComponent<Rigidbody>();
+
+        maxPoints =  Mathf.Round(rewindTime / timeBetweenSaves);
+        Record();
+    }
+
+    private void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.W))
+        {
+            StartCoroutine(Rewind());
+        }
+    }
+
+    public void FixedUpdate()
+    {
+        if (isMoving && !isRewinding)
+        {
+            if(timeSinceLastSave < timeBetweenSaves)
+            {
+                timeSinceLastSave += Time.fixedDeltaTime;
+            }
+            else if(timeSinceLastSave >= timeBetweenSaves)
+            {
+                Record();
+                timeSinceLastSave = 0f;
+            }
+        }
+        else if (objectPhysics.velocity.magnitude >= 0.01 || objectPhysics.angularVelocity.magnitude >= 0.01)
+        {
+            isMoving = true;
+        }
+    }
+
+    private IEnumerator Rewind()
+    {
+        isRewinding = true;
+        objectPhysics.isKinematic = true;
+
+        PastReference pointInTime;
+        Vector3 initialPosition, finalPosition;
+        Quaternion initialRotation, finalRotation;
+        float elapsedTime = 0f;
+        float timeToPreviousReference;
+
+        Vector3 velocity = objectPhysics.velocity;
+        Vector3 angularVelocity = objectPhysics.angularVelocity;
+
+        bool isFromAReference = false;
+
+        while(isRewinding && references.Count > 0)
+        {
+            pointInTime = references[references.Count - 1];
+            velocity = pointInTime.velocity;
+            angularVelocity = pointInTime.angularVelocity;
+
+            initialPosition = transform.position;
+            finalPosition = pointInTime.position;
+
+            initialRotation = transform.rotation;
+            finalRotation = pointInTime.rotation;
+
+            if (!isFromAReference)
+            {
+                timeToPreviousReference = timeSinceLastSave;
+                isFromAReference = true;
+            }
+            else
+            {
+                timeToPreviousReference = timeBetweenSaves;
+            }
+            
+            elapsedTime = 0f;
+
+            while(isRewinding && elapsedTime < timeToPreviousReference)
+            {
+                transform.position = Vector3.Lerp(initialPosition, finalPosition, elapsedTime / timeToPreviousReference);
+                transform.rotation = Quaternion.Lerp(initialRotation, finalRotation, elapsedTime / timeToPreviousReference);
+
+                elapsedTime += Time.deltaTime;
+                yield return null;
+            }
+
+            if(elapsedTime >= timeToPreviousReference)
+            {
+                transform.position = finalPosition;
+                transform.rotation = finalRotation;
+
+                references.RemoveAt(references.Count - 1);
+            }
+        }
+
+        isRewinding = false;
+        objectPhysics.isKinematic = false;
+
+        objectPhysics.velocity = velocity;
+        objectPhysics.angularVelocity = angularVelocity;
+
+        timeSinceLastSave = timeBetweenSaves - elapsedTime;
+    }
+
+    private void Record()
+    {
+        if(references.Count > maxPoints)
+        {
+            references.RemoveAt(0);
+        }
+
+        references.Add(new PastReference(transform.position, transform.rotation, objectPhysics.velocity, objectPhysics.angularVelocity));
+    }
+}

--- a/Assets/Scripts/ObjectRewind.cs.meta
+++ b/Assets/Scripts/ObjectRewind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e402f182bfe19004588e0e21fb2edf97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Throughout the lifetime of an object, references of its position, rotation, velocity, and angular velocity are recorded at specified intervals. When [R] is pressed, objects rewind to these past references for the rewind time. A rewind cooldown is activated on the objects immediately after they rewind, during which point the objects can not enter another rewind cycle. In the ObjectRewind_CDominguez scene, press [Space] to initiate an explosion at the base of a cube pile for testing.